### PR TITLE
Handle YouTube attribution_links

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,13 @@ function youtube(str) {
 		var elements = str.split('/');
 		return stripParameters(elements.pop());
 	}
+
+	// attribution_link
+	var attrreg = /\/attribution_link\?.*v%3D([^%&]*)(%26|&|$)/;
+
+	if (attrreg.test(str)) {
+		return str.match(attrreg)[1];
+	}
 }
 
 /**

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,11 @@ http://www.youtube.com/user/username#p/u/1/*
 www.youtube-nocookie.com/embed/*?
 ```
 
+**Youtube attribution_link**
+```
+http://www.youtube.com/attribution_link?u=%2Fwatch%3Fv%3D*%26
+```
+
 **Vimeo urls**
 ```
 https://vimeo.com/*

--- a/test.js
+++ b/test.js
@@ -91,6 +91,10 @@ test('gets vine id from postcard vine iframe embeds', t => {
  *  // iframe embed
  *  <iframe width="560" height="315" src="https://www.youtube.com/embed/*" frameborder="0" allowfullscreen></iframe>
  *
+ *  // attribution_link
+ *  http://www.youtube.com/attribution_link?u=%2Fwatch%3Fv%3D*%26
+ *  https://www.youtube.com/attribution_link?u=%2Fwatch%3Fv%3D*%26
+ *
  */
 
 test('gets youtube id from iframe', t => {
@@ -145,6 +149,11 @@ test('removes -nocookie', t => {
 	t.is(fn('http://www.youtube-nocookie.com/v/ABC12301'), 'ABC12301');
 	t.is(fn('http://www.youtube-nocookie.com/user/username#p/u/1/ABC12302'), 'ABC12302');
 	t.is(fn('https://www.youtube-nocookie.com/embed/ABC12303'), 'ABC12303');
+});
+
+test('handles youtube attribution_links', t => {
+	t.is(fn('http://www.youtube.com/attribution_link?u=%2Fwatch%3Fv%3DABC12300%26feature%3Dshare&a=JdfC0C9V6ZI'), 'ABC12300');
+	t.is(fn('https://www.youtube.com/attribution_link?a=JdfC0C9V6ZI&u=%2Fwatch%3Fv%3DABC12301%26feature%3Dshare'), 'ABC12301');
 });
 
 test('expects a string', t => {


### PR DESCRIPTION
Hi, I've added support for parsing YouTube attribution links like [this one](https://www.youtube.com/attribution_link?a=pem1M9ptzYE&u=%2Fwatch%3Fv%3DGlQIzbmis2M%26feature%3Dshare) (`https://www.youtube.com/attribution_link?a=pem1M9ptzYE&u=%2Fwatch%3Fv%3DGlQIzbmis2M%26feature%3Dshare`). These links are created by selecting the Share option followed by, say, Share to Reddit.

Such a link references another url-encoded link, which is why I chose to use a slightly-complex regex over `String#split`.

Refs: meandavejustice/min-vid#226