### PR TITLE
Return metadata object instead of string

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,16 +12,25 @@ module.exports = function (str) {
 	// remove the '-nocookie' flag from youtube urls
 	str = str.replace('-nocookie', '');
 
-	var id;
+	var metadata;
 
 	if (/youtube|youtu\.be/.test(str)) {
-		id = youtube(str);
+		metadata = {
+			id: youtube(str),
+			service: 'youtube'
+		};
 	} else if (/vimeo/.test(str)) {
-		id = vimeo(str);
+		metadata = {
+			id: vimeo(str),
+			service: 'vimeo'
+		};
 	} else if (/vine/.test(str)) {
-		id = vine(str);
+		metadata = {
+			id: vine(str),
+			service: 'vine'
+		};
 	}
-	return id;
+	return metadata;
 };
 
 /**

--- a/test.js
+++ b/test.js
@@ -14,15 +14,18 @@ import fn from './';
  *
  */
 
-test('gets vimeo id', t => {
-	t.is(fn('https://player.vimeo.com/video/123450987'), '123450987');
-	t.is(fn('https://vimeo.com/1230897'), '1230897');
-	t.is(fn('https://vimeo.com/140542479#t=0m3s'), '140542479');
+test('gets vimeo metadata from url', t => {
+	t.is(fn('https://player.vimeo.com/video/123450987').id, '123450987');
+	t.is(fn('https://vimeo.com/1230897').id, '1230897');
+	t.is(fn('https://vimeo.com/140542479#t=0m3s').id, '140542479');
+
+	t.is(fn('https://player.vimeo.com/video/123450987#t=0m3s').service, 'vimeo');
 });
 
-test('gets vimeo id from iframe', t => {
+test('gets vimeo metadata from iframe', t => {
 	const str = '<iframe src="https://player.vimeo.com/video/97682350" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe> <p><a href="https://vimeo.com/97682350">Todo list application utilizing the Swift programming language</a> from <a href="https://vimeo.com/user27750098">Rex Fatahi</a> on <a href="https://vimeo.com">Vimeo</a>.</p>';
-	t.is(fn(str), '97682350');
+	t.is(fn(str).id, '97682350');
+	t.is(fn(str).service, 'vimeo');
 });
 
 /**
@@ -37,23 +40,30 @@ test('gets vimeo id from iframe', t => {
  *
  */
 
-test('gets vine id', t => {
-	t.is(fn('https://vine.co/v/e5vIvmV5v9J'), 'e5vIvmV5v9J');
-	t.is(fn('https://vine.co/v/e5vIvmV5v9J/'), 'e5vIvmV5v9J');
-	t.is(fn('https://vine.co/v/e5vIvmV5v9J/embed'), 'e5vIvmV5v9J');
-	t.is(fn('https://vine.co/v/e5vIvmV5v9J/card?api=1/'), 'e5vIvmV5v9J');
-	t.is(fn('https://vine.co/v/bjpPT1xwg6B/embed/simple'), 'bjpPT1xwg6B');
-	t.is(fn('https://vine.co/v/bjpPT1xwg6B/embed/postcard?audio=1'), 'bjpPT1xwg6B');
+test('gets vine metadata from url', t => {
+	t.is(fn('https://vine.co/v/e5vIvmV5v9J').id, 'e5vIvmV5v9J');
+	t.is(fn('https://vine.co/v/e5vIvmV5v9J/').id, 'e5vIvmV5v9J');
+	t.is(fn('https://vine.co/v/e5vIvmV5v9J/embed').id, 'e5vIvmV5v9J');
+	t.is(fn('https://vine.co/v/e5vIvmV5v9J/card?api=1/').id, 'e5vIvmV5v9J');
+	t.is(fn('https://vine.co/v/bjpPT1xwg6B/embed/simple').id, 'bjpPT1xwg6B');
+	t.is(fn('https://vine.co/v/bjpPT1xwg6B/embed/postcard?audio=1').id, 'bjpPT1xwg6B');
+
+	t.is(fn('https://vine.co/v/e5vIvmV5v9J/').service, 'vine');
+	t.is(fn('https://vine.co/v/bjpPT1xwg6B/embed/postcard?audio=1').service, 'vine');
 });
 
-test('gets vine id from simple vine iframe embeds', t => {
+test('gets vine metadata from iframe', t => {
 	const str = '<iframe src="https://vine.co/v/bjpPT1xwg6B/embed/simple" width="600" height="600" frameborder="0"></iframe>';
-	t.is(fn(str), 'bjpPT1xwg6B');
+
+	t.is(fn(str).id, 'bjpPT1xwg6B');
+	t.is(fn(str).service, 'vine');
 });
 
-test('gets vine id from postcard vine iframe embeds', t => {
+test('gets vine metadata from postcard iframe', t => {
 	const str = '<iframe src="https://vine.co/v/bjpPT1xwg6B/embed/postcard" width="600" height="600" frameborder="0"></iframe>';
-	t.is(fn(str), 'bjpPT1xwg6B');
+
+	t.is(fn(str).id, 'bjpPT1xwg6B');
+	t.is(fn(str).service, 'vine');
 });
 
 /**
@@ -97,67 +107,83 @@ test('gets vine id from postcard vine iframe embeds', t => {
  *
  */
 
-test('gets youtube id from iframe', t => {
+test('gets youtube metadata from iframe', t => {
 	const str = '<iframe width="560" height="315" src="https://www.youtube.com/embed/97682350" frameborder="0" allowfullscreen></iframe>';
-	t.is(fn(str), '97682350');
+
+	t.is(fn(str).id, '97682350');
+	t.is(fn(str).service, 'youtube');
 });
 
-test('gets youtube shortcode formats', t => {
-	t.is(fn('youtube://ABC12301'), 'ABC12301');
-	t.is(fn('https://youtu.be/ABC12302'), 'ABC12302');
-	t.is(fn('http://youtu.be/ABC12303'), 'ABC12303');
-	t.is(fn('http://youtu.be/ABC12304?feature=youtube_gdata_player'), 'ABC12304');
+test('gets metadata from youtube shortcode formats', t => {
+	t.is(fn('youtube://ABC12301').id, 'ABC12301');
+	t.is(fn('https://youtu.be/ABC12302').id, 'ABC12302');
+	t.is(fn('http://youtu.be/ABC12303').id, 'ABC12303');
+	t.is(fn('http://youtu.be/ABC12304?feature=youtube_gdata_player').id, 'ABC12304');
+
+	t.is(fn('http://youtu.be/ABC12304?feature=youtube_gdata_player').service, 'youtube');
 });
 
 test('handles youtube v= and vi= formats', t => {
-	t.is(fn('http://www.youtube.com/ytscreeningroom?v=ABC1230'), 'ABC1230');
-	t.is(fn('https://www.youtube.com/watch?v=ABC12301'), 'ABC12301');
-	t.is(fn('http://www.youtube.com/watch?v=ABC12302&list=abc123&index=2&feature=plpp_video'), 'ABC12302');
-	t.is(fn('http://www.youtube.com/watch?v=ABC12303&feature=channel'), 'ABC12303');
-	t.is(fn('http://www.youtube.com/watch?v=ABC12304&playnext_from=TL&videos=abc123&feature=sub'), 'ABC12304');
-	t.is(fn('http://www.youtube.com/watch?v=ABC12305&feature=channel'), 'ABC12305');
-	t.is(fn('http://www.youtube.com/watch?v=ABC12306&playnext_from=TL&videos=abc123&feature=sub'), 'ABC12306');
-	t.is(fn('http://www.youtube.com/watch?v=ABC12307'), 'ABC12307');
-	t.is(fn('http://youtube.com/?v=ABC12308&feature=youtube_gdata_player'), 'ABC12308');
-	t.is(fn('http://youtube.com/?vi=ABC12309&feature=youtube_gdata_player'), 'ABC12309');
-	t.is(fn('http://youtube.com/watch?v=ABC12310&feature=youtube_gdata_player'), 'ABC12310');
-	t.is(fn('http://youtube.com/watch?vi=ABC12311&feature=youtube_gdata_player'), 'ABC12311');
-	t.is(fn('http://www.youtube.com/watch?v=ABC12312&feature=youtube_gdata_player'), 'ABC12312');
-	t.is(fn('http://www.youtube.com/watch?v=ABC12313&feature=youtu.be'), 'ABC12313');
+	t.is(fn('http://www.youtube.com/ytscreeningroom?v=ABC1230').id, 'ABC1230');
+	t.is(fn('https://www.youtube.com/watch?v=ABC12301').id, 'ABC12301');
+	t.is(fn('http://www.youtube.com/watch?v=ABC12302&list=abc123&index=2&feature=plpp_video').id, 'ABC12302');
+	t.is(fn('http://www.youtube.com/watch?v=ABC12303&feature=channel').id, 'ABC12303');
+	t.is(fn('http://www.youtube.com/watch?v=ABC12304&playnext_from=TL&videos=abc123&feature=sub').id, 'ABC12304');
+	t.is(fn('http://www.youtube.com/watch?v=ABC12305&feature=channel').id, 'ABC12305');
+	t.is(fn('http://www.youtube.com/watch?v=ABC12306&playnext_from=TL&videos=abc123&feature=sub').id, 'ABC12306');
+	t.is(fn('http://www.youtube.com/watch?v=ABC12307').id, 'ABC12307');
+	t.is(fn('http://youtube.com/?v=ABC12308&feature=youtube_gdata_player').id, 'ABC12308');
+	t.is(fn('http://youtube.com/?vi=ABC12309&feature=youtube_gdata_player').id, 'ABC12309');
+	t.is(fn('http://youtube.com/watch?v=ABC12310&feature=youtube_gdata_player').id, 'ABC12310');
+	t.is(fn('http://youtube.com/watch?vi=ABC12311&feature=youtube_gdata_player').id, 'ABC12311');
+	t.is(fn('http://www.youtube.com/watch?v=ABC12312&feature=youtube_gdata_player').id, 'ABC12312');
+	t.is(fn('http://www.youtube.com/watch?v=ABC12313&feature=youtu.be').id, 'ABC12313');
+
+	t.is(fn('http://www.youtube.com/watch?v=ABC12306&playnext_from=TL&videos=abc123&feature=sub').service, 'youtube');
 });
 
 test('handles youtube /v/ and /vi/ formats', t => {
-	t.is(fn('http://www.youtube.com/v/ABC1230'), 'ABC1230');
-	t.is(fn('http://youtube.com/v/ABC12301?feature=youtube_gdata_player'), 'ABC12301');
-	t.is(fn('http://youtube.com/vi/ABC12302?feature=youtube_gdata_player'), 'ABC12302');
+	t.is(fn('http://www.youtube.com/v/ABC1230').id, 'ABC1230');
+	t.is(fn('http://youtube.com/v/ABC12301?feature=youtube_gdata_player').id, 'ABC12301');
+	t.is(fn('http://youtube.com/vi/ABC12302?feature=youtube_gdata_player').id, 'ABC12302');
+
+	t.is(fn('http://youtube.com/vi/ABC12302?feature=youtube_gdata_player').service, 'youtube');
 });
 
 test('handles youtube /embed/ formats', t => {
-	t.is(fn('https://www.youtube.com/embed/ABC1230'), 'ABC1230');
-	t.is(fn('www.youtube-nocookie.com/embed/ABC12301?rel=0'), 'ABC12301');
-	t.is(fn('http://www.youtube.com/embed/ABC12302?rel=0'), 'ABC12302');
+	t.is(fn('https://www.youtube.com/embed/ABC1230').id, 'ABC1230');
+	t.is(fn('www.youtube-nocookie.com/embed/ABC12301?rel=0').id, 'ABC12301');
+	t.is(fn('http://www.youtube.com/embed/ABC12302?rel=0').id, 'ABC12302');
+
+	t.is(fn('http://www.youtube.com/embed/ABC12302?rel=0').service, 'youtube');
 });
 
 test('handles youtube /user/ formats', t => {
-	t.is(fn('http://www.youtube.com/user/username#p/u/1/ABC1230'), 'ABC1230');
-	t.is(fn('http://www.youtube.com/user/username#p/a/u/2/ABC12301'), 'ABC12301');
-	t.is(fn('http://www.youtube.com/user/username#p/u/1/ABC12302?rel=0'), 'ABC12302');
+	t.is(fn('http://www.youtube.com/user/username#p/u/1/ABC1230').id, 'ABC1230');
+	t.is(fn('http://www.youtube.com/user/username#p/a/u/2/ABC12301').id, 'ABC12301');
+	t.is(fn('http://www.youtube.com/user/username#p/u/1/ABC12302?rel=0').id, 'ABC12302');
+
+	t.is(fn('http://www.youtube.com/user/username#p/u/1/ABC12302?rel=0').service, 'youtube');
 });
 
 test('removes -nocookie', t => {
-	t.is(fn('http://www.youtube-nocookie.com/ytscreeningroom?v=ABC12300'), 'ABC12300');
-	t.is(fn('http://www.youtube-nocookie.com/v/ABC12301'), 'ABC12301');
-	t.is(fn('http://www.youtube-nocookie.com/user/username#p/u/1/ABC12302'), 'ABC12302');
-	t.is(fn('https://www.youtube-nocookie.com/embed/ABC12303'), 'ABC12303');
+	t.is(fn('http://www.youtube-nocookie.com/ytscreeningroom?v=ABC12300').id, 'ABC12300');
+	t.is(fn('http://www.youtube-nocookie.com/v/ABC12301').id, 'ABC12301');
+	t.is(fn('http://www.youtube-nocookie.com/user/username#p/u/1/ABC12302').id, 'ABC12302');
+	t.is(fn('https://www.youtube-nocookie.com/embed/ABC12303').id, 'ABC12303');
+
+	t.is(fn('http://www.youtube-nocookie.com/user/username#p/u/1/ABC12302').service, 'youtube');
 });
 
 test('handles youtube attribution_links', t => {
-	t.is(fn('http://www.youtube.com/attribution_link?u=%2Fwatch%3Fv%3DABC12300%26feature%3Dshare&a=JdfC0C9V6ZI'), 'ABC12300');
-	t.is(fn('https://www.youtube.com/attribution_link?a=JdfC0C9V6ZI&u=%2Fwatch%3Fv%3DABC12301%26feature%3Dshare'), 'ABC12301');
-	t.is(fn('http://www.youtube.com/attribution_link?u=/watch?v=ABC12302&feature=share&list=UUsnCjinFcybOuyJU1NFOJmg&a=LjnCygXKl21WkJdyKu9O-w'), 'ABC12302');
-	t.is(fn('http://www.youtube.com/attribution_link?u=/watch?v=ABC12303&feature=share&a=9QlmP1yvjcllp0h3l0NwuA'), 'ABC12303');
-	t.is(fn('http://www.youtube.com/attribution_link?a=fF1CWYwxCQ4&u=/watch?v=ABC12304&feature=em-uploademail'), 'ABC12304');
-	t.is(fn('http://www.youtube.com/attribution_link?a=fF1CWYwxCQ4&feature=em-uploademail&u=/watch?v=ABC12305'), 'ABC12305');
+	t.is(fn('http://www.youtube.com/attribution_link?u=%2Fwatch%3Fv%3DABC12300%26feature%3Dshare&a=JdfC0C9V6ZI').id, 'ABC12300');
+	t.is(fn('https://www.youtube.com/attribution_link?a=JdfC0C9V6ZI&u=%2Fwatch%3Fv%3DABC12301%26feature%3Dshare').id, 'ABC12301');
+	t.is(fn('http://www.youtube.com/attribution_link?u=/watch?v=ABC12302&feature=share&list=UUsnCjinFcybOuyJU1NFOJmg&a=LjnCygXKl21WkJdyKu9O-w').id, 'ABC12302');
+	t.is(fn('http://www.youtube.com/attribution_link?u=/watch?v=ABC12303&feature=share&a=9QlmP1yvjcllp0h3l0NwuA').id, 'ABC12303');
+	t.is(fn('http://www.youtube.com/attribution_link?a=fF1CWYwxCQ4&u=/watch?v=ABC12304&feature=em-uploademail').id, 'ABC12304');
+	t.is(fn('http://www.youtube.com/attribution_link?a=fF1CWYwxCQ4&feature=em-uploademail&u=/watch?v=ABC12305').id, 'ABC12305');
+
+	t.is(fn('http://www.youtube.com/attribution_link?u=/watch?v=ABC12302&feature=share&list=UUsnCjinFcybOuyJU1NFOJmg&a=LjnCygXKl21WkJdyKu9O-w').service, 'youtube');
 });
 
 test('expects a string', t => {


### PR DESCRIPTION
The `get-video-id` package is useful because it allows you to easily get the id of a video from a url/iframe, but I believe that it should do slightly more.  As a client of the `get-video-id` package, I am not only interested in the `id`, but also from which service the id sprang.

It would be a shame if every client needed to write its own regexes to figure out which service the id is from when it is actually calculated within this package!   While for most cases it may seem trivial ( `indexOf( 'youtube' ) >= 0` ), there are edge cases (youtu.be).

This PR aims to make it so that rather than:
`getVideoId = (videoSrc | iframe) --> videoId`

The function will behave like:
`getVideoId = (videoSrc | iframe) --> { id: videoId, service: 'youtube' }`

TODO:
- [ ] update readme