### PR TITLE
Support for VideoPress urls and iframes

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,11 @@ module.exports = function (str) {
 			id: vine(str),
 			service: 'vine'
 		};
+	} else if (/videopress/.test(str)) {
+		metadata = {
+			id: videopress(str),
+			service: 'videopress'
+		};
 	}
 	return metadata;
 };
@@ -115,6 +120,22 @@ function youtube(str) {
 	if (attrreg.test(str)) {
 		return str.match(attrreg)[1];
 	}
+}
+
+/**
+ * Get the VideoPress id.
+ * @param {string} str - the url from which you want to extract the id
+ * @returns {string|undefined}
+ */
+function videopress(str) {
+	var idRegex;
+	if (str.indexOf('embed') > -1) {
+		idRegex = /embed\/(\w{8})/;
+		return str.match(idRegex)[1];
+	}
+
+	idRegex = /\/v\/(\w{8})/;
+	return str.match(idRegex)[1];
 }
 
 /**

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://travis-ci.org/radiovisual/get-video-id.svg?branch=master)](https://travis-ci.org/radiovisual/get-video-id) [![Coverage Status](https://coveralls.io/repos/github/radiovisual/get-video-id/badge.svg?branch=master)](https://coveralls.io/github/radiovisual/get-video-id?branch=master)
 
-This module will extract the YouTube, Vimeo, or Vine Video ID from any known YouTube, Vimeo or Vine url patterns, including embed strings.
+This module will extract the YouTube, Vimeo, Vine, or VideoPress Video ID from any known YouTube, Vimeo, Vine, or VideoPress url patterns, including embed strings.
 **Pull Requests are welcome** if you would like to see support for other video services or if you find an unsupported video url pattern.
 
 
@@ -150,6 +150,18 @@ https://vine.co/v/*
 ```
 <iframe src="https://vine.co/v/*/embed/simple" width="600" height="600" frameborder="0"></iframe>
 <iframe src="https://vine.co/v/*/embed/postcard" width="600" height="600" frameborder="0"></iframe>
+```
+
+
+**VideoPress urls**
+```
+https://videopress.com/v/*
+https://videopress.com/embed/*
+```
+
+**VideoPress iframes**
+```
+<iframe src="https://videopress.com/embed/zcnJVzQF" width="600" height="600"></iframe>
 ```
 
 ## Contributing

--- a/test.js
+++ b/test.js
@@ -32,7 +32,7 @@ test('gets vimeo metadata from iframe', t => {
  *  VideoPress should be able to find these patterns:
  *
  *  // urls
- * 	https://videopress.com/v/*
+ *  https://videopress.com/v/*
  *  https://videopress.com/embed/*
  *
  *  // iframe

--- a/test.js
+++ b/test.js
@@ -29,6 +29,32 @@ test('gets vimeo metadata from iframe', t => {
 });
 
 /**
+ *  VideoPress should be able to find these patterns:
+ *
+ *  // urls
+ * 	https://videopress.com/v/*
+ *  https://videopress.com/embed/*
+ *
+ *  // iframe
+ *  <iframe src="https://videopress.com/embed/zcnJVzQF"
+ *
+ */
+
+test('gets videopress metadata from url', t => {
+	t.is(fn('https://videopress.com/v/dyrgndFq').id, 'dyrgndFq');
+	t.is(fn('https://videopress.com/v/dyrgndFq#fullscreen').id, 'dyrgndFq');
+	t.is(fn('https://videopress.com/embed/zcnJVzQz?hd=0&autoPlay=0&permalink=0&loop=0').id, 'zcnJVzQz');
+
+	t.is(fn('https://videopress.com/embed/zcnJVzQz?hd=0&autoPlay=0&permalink=0&loop=0').service, 'videopress');
+});
+
+test('gets videopress metadata from iframe', t => {
+	var str = '<iframe width="400" height="300" src="https://videopress.com/embed/zcnJVzQz?hd=0&amp;autoPlay=0&amp;permalink=0&amp;loop=0" frameborder="0" allowfullscreen="" sandbox="allow-same-origin allow-scripts allow-popups"></iframe>';
+	t.is(fn(str).id, 'zcnJVzQz');
+	t.is(fn(str).service, 'videopress');
+});
+
+/**
  *  Vine should be able to find these patterns:
  *
  *  // urls


### PR DESCRIPTION
Hi @radiovisual.
We've been using this package in [wp-calypso](https://github.com/Automattic/wp-calypso) for a bit now and its been working great! Thank you for all the effort you've put in with maintaining this package.

I've added in support for VideoPress urls / iframes, updated the docs, and added relevant tests.
Feel free to merge/edit  if you are interested!