### PR TITLE
Vimeo should be able to handle querystrings

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,10 @@ function vimeo(str) {
 	if (str.indexOf('#') > -1) {
 		str = str.split('#')[0];
 	}
+	if (str.indexOf('?') > -1) {
+		str = str.split('?')[0];
+	}
+
 	var id;
 	if (/https?:\/\/vimeo\.com\/[0-9]+$|https?:\/\/player\.vimeo\.com\/video\/[0-9]+$/igm.test(str)) {
 		var arr = str.split('/');

--- a/test.js
+++ b/test.js
@@ -18,6 +18,7 @@ test('gets vimeo metadata from url', t => {
 	t.is(fn('https://player.vimeo.com/video/123450987').id, '123450987');
 	t.is(fn('https://vimeo.com/1230897').id, '1230897');
 	t.is(fn('https://vimeo.com/140542479#t=0m3s').id, '140542479');
+	t.is(fn('https://player.vimeo.com/video/176337266?color=ffffff&title=0&byline=0&portrait=0&badge=0').id, '176337266');
 
 	t.is(fn('https://player.vimeo.com/video/123450987#t=0m3s').service, 'vimeo');
 });


### PR DESCRIPTION
As the title says, currently `get-video-id` will return an undefined `id` for any vimeo url with a query string.  This PR strips all of the querystrings from the url.

I've also added an example unit tests for a url with a query string. 
All old tests still pass.