### PR TITLE
Trimming the input to remove whitespaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ module.exports = function (str) {
 		str = getSrc(str);
 	}
 
+	// remove surrounding whitespaces or linefeeds
+	str = str.trim();
+
 	// remove the '-nocookie' flag from youtube urls
 	str = str.replace('-nocookie', '');
 


### PR DESCRIPTION
I was piping the content of a file containing the link to a YouTube video into the function and got back the ID with a linefeed after it.

Sure, I could also trim my input, but still that shouldn't happen.