### PR TITLE
Return empty object as default value

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function (str) {
 	// remove any leading `www.`
 	str = str.replace('/www.', '/');
 
-	var metadata;
+	var metadata = {};
 
 	// Try to handle google redirection uri
 	if (/\/\/google/.test(str)) {

--- a/test.js
+++ b/test.js
@@ -269,5 +269,5 @@ test('handles google redirection to vimeo', t => {
 });
 
 test('google link returns empty object if missing url parameter', t => {
-	t.is(fn('https://www.google.cz/url?sa=t&rct=j&q=&esrc=s&source=web&cd=2&ved=0ahUKEwiz9P3Aw5DVAhUDZVAKHcegCi8QuAIINDAB&usg=AFQjCNG0kTPdL8nC6zCi2QoZ1KVeTXH-pw'), {});
+	t.is(Object.keys(fn('https://www.google.cz/url?sa=t&rct=j&q=&esrc=s&source=web&cd=2&ved=0ahUKEwiz9P3Aw5DVAhUDZVAKHcegCi8QuAIINDAB&usg=AFQjCNG0kTPdL8nC6zCi2QoZ1KVeTXH-pw')).length, 0);
 });

--- a/test.js
+++ b/test.js
@@ -268,6 +268,6 @@ test('handles google redirection to vimeo', t => {
 	t.is(fn(url).service, 'vimeo');
 });
 
-test('google link returns undefined if missing url parameter', t => {
-	t.is(fn('https://www.google.cz/url?sa=t&rct=j&q=&esrc=s&source=web&cd=2&ved=0ahUKEwiz9P3Aw5DVAhUDZVAKHcegCi8QuAIINDAB&usg=AFQjCNG0kTPdL8nC6zCi2QoZ1KVeTXH-pw'), undefined);
+test('google link returns empty object if missing url parameter', t => {
+	t.is(fn('https://www.google.cz/url?sa=t&rct=j&q=&esrc=s&source=web&cd=2&ved=0ahUKEwiz9P3Aw5DVAhUDZVAKHcegCi8QuAIINDAB&usg=AFQjCNG0kTPdL8nC6zCi2QoZ1KVeTXH-pw'), {});
 });


### PR DESCRIPTION
Hello,

The change aim to have a consistent API.

Currently, it the library doesn't find a compatible service, it returns undefined, being impossible destructuring and get `id` and `service` as usual without throw an error:

```js
const {id, service} = getId() // throw global error, lol
````

with this change, simply it returns an empty object 🙂