### PR TITLE
Fix get id when pass user videos url

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ function youtube(str) {
 	}
 
 	// user
-	var userreg = /\/user\//g;
+	var userreg = /\/user\/(?!.*videos)/g;
 
 	if (userreg.test(str)) {
 		var elements = str.split('/');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "get-video-id",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -232,6 +232,7 @@ test('handles youtube v= and vi= formats', t => {
 	t.is(fn('http://youtube.com/watch?vi=ABC12311&feature=youtube_gdata_player').id, 'ABC12311');
 	t.is(fn('http://www.youtube.com/watch?v=ABC12312&feature=youtube_gdata_player').id, 'ABC12312');
 	t.is(fn('http://www.youtube.com/watch?v=ABC12313&feature=youtu.be').id, 'ABC12313');
+	t.is(fn('https://www.youtube.com/user/ThreeDaysGraceVideos/videos').id, undefined);
 
 	t.is(fn('http://www.youtube.com/watch?v=ABC12306&playnext_from=TL&videos=abc123&feature=sub').service, 'youtube');
 });


### PR DESCRIPTION
When i passed https://www.youtube.com/user/ThreeDaysGraceVideos/videos' i have got 

`{ id: 'videos', service: 'youtube' }`

Of course 'videos' is not id in this case :) 
I fixed that problem and wrote test for that case. I hope I'll merge or fix this case by yourself implementation because I need this package so much.

Thank you