### PR TITLE
Add y2u.be shortcode pattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function (str) {
 		}
 	}
 
-	if (/youtube|youtu\.be|i.ytimg\./.test(str)) {
+	if (/youtube|youtu\.be|y2u\.be|i.ytimg\./.test(str)) {
 		metadata = {
 			id: youtube(str),
 			service: 'youtube'
@@ -106,7 +106,7 @@ function vine(str) {
  */
 function youtube(str) {
 	// shortcode
-	var shortcode = /youtube:\/\/|https?:\/\/youtu\.be\//g;
+	var shortcode = /youtube:\/\/|https?:\/\/youtu\.be\/|http:\/\/y2u\.be\//g;
 
 	if (shortcode.test(str)) {
 		var shortcodeid = str.split(shortcode)[1];

--- a/readme.md
+++ b/readme.md
@@ -10,8 +10,8 @@ This module will extract the YouTube, Vimeo, Vine, or VideoPress Video ID from a
 
 ## Version 3.0 (Breaking Change)
 
-`get-video-id` now returns an empty object instead of `undefined` if an id or service could not be found. This keeps the 
-API consistant, but also allows for clean destructuring: 
+`get-video-id` now returns an empty object instead of `undefined` if an id or service could not be found. This keeps the
+API consistant, but also allows for clean destructuring:
 
 ```js
 const {id, service} = getVideoId('foo');
@@ -95,6 +95,7 @@ This module works on the url / embed patterns below.
 http://youtu.be/*?
 https://youtu.be/*
 http://youtu.be/*
+http://y2u.be/*
 youtube://
 ```
 

--- a/test.js
+++ b/test.js
@@ -167,6 +167,7 @@ test('vine links returns undefined id if id missing', t => {
  *  http://youtu.be/*?
  *  https://youtu.be/*
  *  http://youtu.be/*
+ * 	http://y2u.be/*
  *  youtube://
  *
  *  // /v/ or /vi/
@@ -213,6 +214,7 @@ test('gets metadata from youtube shortcode formats', t => {
 	t.is(fn('https://youtu.be/ABC12302').id, 'ABC12302');
 	t.is(fn('http://youtu.be/ABC12303').id, 'ABC12303');
 	t.is(fn('http://youtu.be/ABC12304?feature=youtube_gdata_player').id, 'ABC12304');
+	t.is(fn('http://y2u.be/ABC12304').id, 'ABC12304');
 
 	t.is(fn('http://youtu.be/ABC12304?feature=youtube_gdata_player').service, 'youtube');
 });


### PR DESCRIPTION
On our project we have found case with y2u.be pattern. Here the link http://y2u.be. 
Case was added to implementation, tests and docs.

Warning: I used http instead of https? for purpose. Because https://y2u.be links doesn't work. 