### PR TITLE
Replace `const` with `var` in vimeo code.

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function vimeo(str) {
 	var id;
 	var arr;
 
-	const vimeoPipe = [
+	var vimeoPipe = [
 		'https?:\/\/vimeo\.com\/[0-9]+$',
 		'https?:\/\/player\.vimeo\.com\/video\/[0-9]+$',
 		'https?:\/\/vimeo\.com\/channels',
@@ -81,7 +81,7 @@ function vimeo(str) {
 		'album'
 	].join('|');
 
-	const vimeoRegex = new RegExp(vimeoPipe, 'gim');
+	var vimeoRegex = new RegExp(vimeoPipe, 'gim');
 
 	if (vimeoRegex.test(str)) {
 		arr = str.split('/');


### PR DESCRIPTION
Since `get-video-id` doesn't have a build process involving transpilation, and since node dependencies typically don't get transpiled, these `const` declarations were making their way into ES5 builds. Replacing them with `var` should do the trick.