### PR TITLE
Support more youtube formats

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ function youtube(str) {
 
 	if (parameterv.test(str)) {
 		var arr = str.split(parameterv);
-		return arr[1].split('&')[0];
+		return stripParameters(arr[1].split('&')[0]);
 	}
 
 	// v= or vi=
@@ -183,7 +183,7 @@ function youtube(str) {
 	var attrreg = /\/attribution_link\?.*v%3D([^%&]*)(%26|&|$)/;
 
 	if (attrreg.test(str)) {
-		return str.match(attrreg)[1];
+		return stripParameters(str.match(attrreg)[1]);
 	}
 }
 
@@ -210,9 +210,9 @@ function videopress(str) {
 }
 
 /**
- * Strip away any parameters following `?` or `/`
+ * Strip away any parameters following `?` or `/` or '&'
  * @param str
- * @returns {*}
+ * @returns {String}
  */
 function stripParameters(str) {
 	// Split parameters or split folder separator
@@ -220,6 +220,8 @@ function stripParameters(str) {
 		return str.split('?')[0];
 	} else if (str.indexOf('/') > -1) {
 		return str.split('/')[0];
+	} else if (str.indexOf('&') > -1) {
+		return str.split('&')[0];
 	}
 	return str;
 }

--- a/index.js
+++ b/index.js
@@ -121,6 +121,9 @@ function vine(str) {
  * @returns {string|undefined}
  */
 function youtube(str) {
+	// remove time hash at the end of the string
+	str = str.replace(/#t=.*$/, '');
+
 	// shortcode
 	var shortcode = /youtube:\/\/|https?:\/\/youtu\.be\/|http:\/\/y2u\.be\//g;
 

--- a/test.js
+++ b/test.js
@@ -269,6 +269,7 @@ test('handles youtube /user/ formats', t => {
 	t.is(fn('http://www.youtube.com/user/username#p/u/1/ABC12302?rel=0').id, 'ABC12302');
 
 	t.is(fn('http://www.youtube.com/user/username#p/u/1/ABC12302?rel=0').service, 'youtube');
+	t.is(fn('https://youtube.com/user/WMFinland#p/a/u/1/G-3YxlZIhus').id, 'G-3YxlZIhus');
 });
 
 test('ignores youtube.com/user/* patterns', t => {
@@ -308,6 +309,14 @@ test('removes time hash at end of string ', t => {
 	t.is(fn('https://www.youtube.com/watch?v=G-3YxlZIhus#t=0m10s').id, 'G-3YxlZIhus');
 	t.is(fn('http://www.youtube.com/watch?v=G-3YxlZIhus#t=0m10s').id, 'G-3YxlZIhus');
 	t.is(fn('http://www.youtube.com/watch?v=G-3YxlZIhus#t=0m10s').service, 'youtube');
+});
+
+test('removes trailing parameters from youtube urls', t => {
+	t.is(fn('http://youtu.be/G-3YxlZIhus&feature=channel').id, 'G-3YxlZIhus');
+	t.is(fn('http://youtube.com/vi/G-3YxlZIhus&feature=channel').id, 'G-3YxlZIhus');
+	t.is(fn('http://youtube.com/vi/G-3YxlZIhus&feature=channel').service, 'youtube');
+	t.is(fn('http://youtube.com/vi/G-3YxlZIhus&feature=share').id, 'G-3YxlZIhus');
+	t.is(fn('http://youtube.com/vi/G-3YxlZIhus&foo=bar').id, 'G-3YxlZIhus');
 });
 
 /**

--- a/test.js
+++ b/test.js
@@ -304,6 +304,12 @@ test('youtube links returns undefined id if id missing', t => {
 	t.is(obj.service, 'youtube');
 });
 
+test('removes time hash at end of string ', t => {
+	t.is(fn('https://www.youtube.com/watch?v=G-3YxlZIhus#t=0m10s').id, 'G-3YxlZIhus');
+	t.is(fn('http://www.youtube.com/watch?v=G-3YxlZIhus#t=0m10s').id, 'G-3YxlZIhus');
+	t.is(fn('http://www.youtube.com/watch?v=G-3YxlZIhus#t=0m10s').service, 'youtube');
+});
+
 /**
  * Google redirect patterns:
  *


### PR DESCRIPTION
Works off of the ideas in #30, where some url formats need to remove the time hash at the end of a string: `#t=0m10s` and also removes any trailing url parameters that might try to attach itself to the `id`:


**Before this PR:**

```javascript
getVideoId('https://www.youtube.com/watch?v=G-3YxlZIhus#t=0m10s').id;
// => 'G-3YxlZIhus#t=0m10s'

getVideoId('http://youtu.be/G-3YxlZIhus&feature=channel').id;
// => 'G-3YxlZIhus&feature=channel'
```

**But this PR will clean up these patterns to return:**

```javascript
getVideoId('https://www.youtube.com/watch?v=G-3YxlZIhus#t=0m10s').id;
// => 'G-3YxlZIhus'

getVideoId('http://youtu.be/G-3YxlZIhus&feature=channel').id;
// => 'G-3YxlZIhus'
```
