### PR TITLE
Add typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,8 @@
+export default function getVideoId(
+	url: string
+):
+	| {}
+	| {
+			id: string;
+			service: "youtube" | "vimeo" | "vine" | "videopress";
+	  };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "dist/get-video-id.js",
   "module": "dist/get-video-id.esm.js",
   "browser": "dist/get-video-id.browser.js",
+  "types": "./index.d.ts",
   "author": {
     "name": "Michael Wuergler",
     "email": "wuergler@gmail.com",


### PR DESCRIPTION
- Add typescript types (related to https://github.com/radiovisual/get-video-id/issues/42)

> Btw having the getVideoId return an empty object (current way) instead of undefined makes type checking jankier than it should by needing to used `'propertyOfObject' in myObject` instead of just `myObject?.propertyOfObject`. **Consider returning undefined instead of an object.**