### PR TITLE
Fix: types missing from bundle. Fixes #42

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "files": [
     "index.js",
-    "dist/*"
+    "dist/*",
+    "index.d.ts"
   ],
   "keywords": [
     "RegExp",


### PR DESCRIPTION
This should be enough to fix the index.d.ts file missing from the bundle. 

A dry run with `npm pack` helps confirm 

![image](https://user-images.githubusercontent.com/5614571/104909869-cc1fea00-5988-11eb-9e27-702be67fdcf2.png)
