### PR TITLE
Fixes #48 - Use UMD for commonjs and browser builds.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "repository": "radiovisual/get-video-id",
   "main": "dist/get-video-id.js",
   "module": "dist/get-video-id.esm.js",
-  "browser": "dist/get-video-id.browser.js",
   "types": "./index.d.ts",
   "author": {
     "name": "Michael Wuergler",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,11 +12,13 @@ export default {
 	output: [
 		{
 			file: pkg.main,
-			format: 'cjs'
+			format: 'umd',
+			name: 'getVideoId'
 		},
 		{
 			file: minified(pkg.main),
-			format: 'cjs'
+			format: 'umd',
+			name: 'getVideoId'
 		},
 		{
 			file: pkg.module,
@@ -25,16 +27,6 @@ export default {
 		{
 			file: minified(pkg.module),
 			format: 'es'
-		},
-		{
-			file: pkg.browser,
-			format: 'iife',
-			name: 'getVideoId'
-		},
-		{
-			file: minified(pkg.browser),
-			format: 'iife',
-			name: 'getVideoId'
 		}
 	],
 


### PR DESCRIPTION
This makes the "main" entry a UMD build suitable for both browser and commonjs consumers.