### PR TITLE
Returning null for unrecognized urls

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,6 @@
 export default function getVideoId(
 	url: string
-):
-	| {}
-	| {
-			id: string;
-			service: "youtube" | "vimeo" | "vine" | "videopress";
-	  };
+): {
+	id: string | null;
+	service: "youtube" | "vimeo" | "vine" | "videopress" | null;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,10 @@ function getVideoId(videoStr) {
   // remove any leading `www.`
   str = str.replace('/www.', '/');
 
-  let metadata = {};
+  let metadata = {
+    id: null,
+    service: null,
+  };
 
   // Try to handle google redirection uri
   if (/\/\/google/.test(str)) {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -8,10 +8,10 @@ test('expects a string', (t) => {
   }, 'get-video-id expects a string');
 });
 
-test('returns empty object', (t) => {
+test('returns null as id and service', (t) => {
   const notFound = fn('foo');
-  t.is(typeof notFound, 'object');
-  t.is(Object.keys(notFound).length, 0);
+  t.is(notFound.id, null);
+  t.is(notFound.service, null);
 });
 
 /**
@@ -339,6 +339,8 @@ test('handles google redirection to vimeo', (t) => {
   t.is(fn(url).service, 'vimeo');
 });
 
-test('google link returns empty object if missing url parameter', (t) => {
-  t.is(Object.keys(fn('https://www.google.cz/url?sa=t&rct=j&q=&esrc=s&source=web&cd=2&ved=0ahUKEwiz9P3Aw5DVAhUDZVAKHcegCi8QuAIINDAB&usg=AFQjCNG0kTPdL8nC6zCi2QoZ1KVeTXH-pw')).length, 0);
+test('google link returns null as id and service if missing url parameter', (t) => {
+  const url = 'https://www.google.cz/url?sa=t&rct=j&q=&esrc=s&source=web&cd=2&ved=0ahUKEwiz9P3Aw5DVAhUDZVAKHcegCi8QuAIINDAB&usg=AFQjCNG0kTPdL8nC6zCi2QoZ1KVeTXH-pw';
+  t.is(fn(url).id, null);
+  t.is(fn(url).service, null);
 });


### PR DESCRIPTION
**Is this a feature, improvement or a bug fix?**

Improvement.

**If you changed any JavaScript files, did you write unit tests?**

Yes.

**Please describe (in detail) the solution(s) provided by your Pull Request**

This is specially useful for Typescript use. With the current typings I get a type error when trying to do things like:

```typescript
const {id, service} = getVideoId(url)
const videoId = getVideoId(url)?.id
const videoService = getVideoId(url)?.service
```

Also I believe `null` is a better return for unsupported URLs than an empty object.

An alternative to this would be to modify just the typings to:

```typescript
export default function getVideoId(
	url: string
): {
	id?: string;
	service?: "youtube" | "vimeo" | "vine" | "videopress";
};
```

But that wouldn't be entirely accurate because it would imply that either the `id` or the `service` can be `null` or `undefined` independently. My proposal ensures that when the url is recognized both are defined.