### PR TITLE
Fix: incomplete iframe src url throws error

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -13,4 +13,6 @@ test('returns null as id and service', () => {
 		service: null,
 	};
 	expect(fn('foo')).toMatchObject(expected);
+	expect(fn('<iframe')).toMatchObject(expected);
+	expect(fn('')).toMatchObject(expected);
 });

--- a/__tests__/utils/get-src.test.js
+++ b/__tests__/utils/get-src.test.js
@@ -29,6 +29,7 @@ describe('get-src', () => {
 
 	test('returns undefined when no src= is found', () => {
 		expect(fn('hello')).toBe(undefined);
+		expect(fn('<iframe')).toBe(undefined);
 	});
 
 	test('single quotes return undefined', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ function getVideoId(urlString) {
 	let string_ = urlString;
 
 	if (/<iframe/gi.test(string_)) {
-		string_ = getSrc(string_);
+		string_ = getSrc(string_) || '';
 	}
 
 	// Remove surrounding whitespaces or linefeeds


### PR DESCRIPTION
Fixes a problem where `getSrc` method would run on a string of `<iframe`, returning `undefined`. This PR catches this case and sets the url string to an empty string instead. Closes #102 