### PR TITLE
Add support for youtube live format

### DIFF
--- a/__tests__/youtube.test.js
+++ b/__tests__/youtube.test.js
@@ -182,6 +182,14 @@ describe('Youtube', () => {
 		expect(fn('http://www.youtube.com/attribution_link?u=/watch?v=ABC12302&feature=share&list=UUsnCjinFcybOuyJU1NFOJmg&a=LjnCygXKl21WkJdyKu9O-w').service).toBe('youtube');
 	});
 
+	test('handles youtube /live/ formats', () => {
+		expect(fn('https://www.youtube.com/live/ABC1230').id).toBe('ABC1230');
+		expect(fn('www.youtube-nocookie.com/live/ABC12301?feature=share').id).toBe('ABC12301');
+		expect(fn('http://www.youtube.com/live/ABC12302?feature=share').id).toBe('ABC12302');
+
+		expect(fn('http://www.youtube.com/live/ABC12302?feature=share').service).toBe('youtube');
+	});
+
 	test('youtube links returns undefined id if id missing', () => {
 		const object = fn('https://www.youtube.com');
 		expect(object.id).toBe(undefined);

--- a/src/youtube.js
+++ b/src/youtube.js
@@ -112,5 +112,13 @@ export default function youtube(youtubeString) {
 		return stripParameters(string_.match(attrreg)[1]);
 	}
 
+	// Live
+	const livereg = /\/live\//g;
+
+	if (livereg.test(string_)) {
+		const liveid = string_.split(livereg)[1];
+		return stripParameters(liveid);
+	}
+
 	return undefined;
 }


### PR DESCRIPTION
Found a new /live/ format that is not supported and added support: should be pretty self-explanatory! 