### PR TITLE
TS support: Updated package.json to fix export of types

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "exports": {
     ".": {
       "import": "./dist/get-video-id.esm.js",
-      "require": "./dist/get-video-id.js"
+      "require": "./dist/get-video-id.js",
+      "types": "./index.d.ts"
     }
   },
   "author": {


### PR DESCRIPTION
Latest release breaks TS support with this new settings block:
```
"exports": {
    ".": {
      "import": "./dist/get-video-id.esm.js",
      "require": "./dist/get-video-id.js",
    }
  }
```
So we can explicitly export types in this block to fix it.
```
"exports": {
    ".": {
      "import": "./dist/get-video-id.esm.js",
      "require": "./dist/get-video-id.js",
      "types": "./index.d.ts"
    }
  },
```