### PR TITLE
ci: update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,29 +9,35 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
       - run: git config --global user.email "wuergler@gmail.com"
       - run: git config --global user.name "Michael Wuergler"
       - run: npm ci
       - name: Extract version from tag
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-      - run: npm version ${{ env.RELEASE_VERSION }}
+      - run: npm version ${{ env.RELEASE_VERSION }} --no-git-tag-version
       - run: npm run build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Commit and push version bump
+        run: |
+          git add package.json
+          git commit -m "chore: bump version to ${{ env.RELEASE_VERSION }}"
+          git push origin HEAD:${{ env.GITHUB_REF#refs/tags/ }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # This step will only run if all previous steps have succeeded
       - name: Create Pull Request for Version Bump
         if: success()
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: Update package version
-          title: 'chore: update package version to ${{ env.RELEASE_VERSION }}'
-          body: 'Updates `package.json` version to `${{ env.RELEASE_VERSION }}`.'
+          commit-message: Update package version to ${{ env.RELEASE_VERSION }}
+          title: "chore: update package version to ${{ env.RELEASE_VERSION }}"
+          body: "Updates `package.json` version to `${{ env.RELEASE_VERSION }}`."
           branch: version-bump/${{ env.RELEASE_VERSION }}
           labels: version-bump
           token: ${{ secrets.GITHUB_TOKEN }}
           base: master
-        


### PR DESCRIPTION
- updates the publish github actions to push the new version number back to the tag when a tag is created on release.
- creates an automated PR to ensure the repo is in sync with the created version number